### PR TITLE
fix pk lookup for games

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'Framework :: Django',
     ],
     install_requires=[
-        "genericclient-aiohttp>=1.2,<1.3",
+        "genericclient-aiohttp>=1.3,<1.4",
     ],
     setup_requires=[
         "pytest-runner",

--- a/simpl_client/games_client.py
+++ b/simpl_client/games_client.py
@@ -1,4 +1,4 @@
-from genericclient_aiohttp import GenericClient, Endpoint
+from genericclient_aiohttp import GenericClient, Endpoint, Resource
 from genericclient_aiohttp.exceptions import HTTPError
 from genericclient_aiohttp.pagination import link_header
 
@@ -127,6 +127,14 @@ Detail Routes
 """
 
 
+class GameResource(Resource):
+    pk_name = 'slug'
+
+
+class GameEndpoint(Endpoint):
+    resource_class = GameResource
+
+
 class BulkEndpoint(Endpoint):
     async def create(self, payload, return_ids=False):
         response = await self.request('post', self.url, json=payload)
@@ -155,6 +163,10 @@ class BulkClient(GenericClient):
 
 
 class GamesAPIClient(GenericClient):
+    endpoint_classes = {
+        'games': GameEndpoint,
+    }
+
     def __init__(self, *args, **kwargs):
         kwargs['trailing_slash'] = True
         kwargs['autopaginate'] = link_header

--- a/tests/test_games_client.py
+++ b/tests/test_games_client.py
@@ -30,6 +30,27 @@ async def test_simpl_all(games_client, register_json):
 
 
 @pytest.mark.asyncio
+async def test_game_save(games_client, register_json):
+    with Mocketizer():
+        register_json(HTTPretty.PUT, '/games/simpl-demo/', json={
+            'id': 1,
+            'slug': 'simpl-demo',
+        })
+
+        register_json(HTTPretty.GET, '/games/simpl-demo/', json={
+            'id': 1,
+            'slug': 'simpl-demo',
+        })
+
+        register_json(HTTPretty.PUT, '/games/1/', status=404)
+
+        game = await games_client.games.get(slug='simpl-demo')
+
+        saved = await game.save()
+        assert saved.slug == 'simpl-demo'
+
+
+@pytest.mark.asyncio
 async def test_simpl_filter(games_client, register_json):
     with Mocketizer():
         register_json(HTTPretty.GET, '/users/?role=player', json=[


### PR DESCRIPTION
The functionality has been added to `genericclient-base` and documented in `genericclient-aiohttp`. See [implementation](https://github.com/genericclient/genericclient-base/commit/af6b3566e99d03334c2ae5c94f5f87664cc1110d) and [docs](https://github.com/genericclient/genericclient-aiohttp#customizing-endpoints-and-resources).
